### PR TITLE
Remove HEAD from limit_except directive in nginx conf files. 

### DIFF
--- a/docker/nginx-ssl.conf
+++ b/docker/nginx-ssl.conf
@@ -49,12 +49,12 @@ http {
         root /usr/share/nginx/html;
 
         location /.well-known/acme-challenge/ {
-            limit_except GET HEAD POST OPTIONS { deny  all; }
+            limit_except GET POST OPTIONS { deny  all; }
             root /var/www/certbot;
         }
 
         location / {
-            limit_except GET HEAD POST OPTIONS { deny  all; }
+            limit_except GET POST OPTIONS { deny  all; }
             return 301 https://layers.openembedded.org$request_uri;
         }
     }
@@ -99,30 +99,30 @@ http {
         root /usr/share/nginx/html;
 
         location /favicon.ico {
-            limit_except GET HEAD POST OPTIONS { deny  all; }
+            limit_except GET POST OPTIONS { deny  all; }
             return 301 https://layers.openembedded.org/static/img/favicon.ico;
         }
 
         location /protected/imagecompare-patches {
             internal;
             add_header X-Status $upstream_http_x_status;
-            limit_except GET HEAD POST OPTIONS { deny  all; }
+            limit_except GET POST OPTIONS { deny  all; }
             root /opt/www;
         }
 
         location / {
-            limit_except GET HEAD POST OPTIONS { deny  all; }
+            limit_except GET POST OPTIONS { deny  all; }
             try_files $uri @proxy_to_app;
         }
 
         location /accounts/login {
-            limit_except GET HEAD POST OPTIONS { deny  all; }
+            limit_except GET POST OPTIONS { deny  all; }
             limit_req zone=login_ip burst=5;
             try_files $uri @proxy_to_app;
         }
 
         location @proxy_to_app {
-            limit_except GET HEAD POST OPTIONS { deny  all; }
+            limit_except GET POST OPTIONS { deny  all; }
 
             proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
             proxy_set_header Host $http_host;

--- a/docker/nginx.conf
+++ b/docker/nginx.conf
@@ -34,17 +34,17 @@ http {
         location /protected/imagecompare-patches {
             internal;
             add_header X-Status $upstream_http_x_status;
-            limit_except GET HEAD POST OPTIONS { deny  all; }
+            limit_except GET POST OPTIONS { deny  all; }
             root /opt/www;
         }
 
         location / {
-            limit_except GET HEAD POST OPTIONS { deny  all; }
+            limit_except GET POST OPTIONS { deny  all; }
             try_files $uri @proxy_to_app;
         }
 
         location @proxy_to_app {
-            limit_except GET HEAD POST OPTIONS { deny  all; }
+            limit_except GET POST OPTIONS { deny  all; }
 
             proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
             proxy_set_header Host $http_host;


### PR DESCRIPTION
Removing unnecessary http method. HEAD is implicit when GET is present.

For further reading about this from the nginx docs: <http://nginx.org/en/docs/http/ngx_http_core_module.html#limit_except>